### PR TITLE
修改创建样式和标题样式

### DIFF
--- a/src/tiddlywiki-ui/popup/CreateNewTiddlerPopup.css
+++ b/src/tiddlywiki-ui/popup/CreateNewTiddlerPopup.css
@@ -19,15 +19,15 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: flex-start;
+  
 }
 .tw-calendar-layout-create-new-tiddler-popup .tw-calendar-tags-input .tw-calendar-frequently-used-tags {
-  max-width: 40%;
+  max-width: 180%;
 }
 .tw-calendar-layout-create-new-tiddler-popup .tw-calendar-tags-input .tc-edit-tags {
   padding-left: 0;
   border: unset;
-  width: 60%;
+  width: 180%;
 }
 .tw-calendar-empty-list-help-text {
   margin: 0;

--- a/src/tiddlywiki-ui/popup/CreateNewTiddlerPopup.tid
+++ b/src/tiddlywiki-ui/popup/CreateNewTiddlerPopup.tid
@@ -4,11 +4,6 @@ footer: {{$:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/C
 
 <div class="tw-calendar-layout-create-new-tiddler-popup">
   Caption:{{$:/state/Calendar/PageLayout/create-tiddler-caption||$:/core/ui/EditTemplate/title}}
-  <small>Title:{{$:/plugins/linonetwo/tw-calendar/settings/prefix}}{{$:/state/Calendar/PageLayout/create-tiddler-caption!!draft.title}}{{$:/state/Calendar/PageLayout/create-tiddler!!draft.title}}</small>
-  <div class="tw-calendar-tags-input">
-    {{$:/state/Calendar/PageLayout/create-tiddler||$:/core/ui/EditTemplate/tags}}
-    {{$:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/FrequentlyUsedTagsList}}
-  </div>
   <$let currentTiddler="$:/state/Calendar/PageLayout/create-tiddler">
     <$edit-text
       field="text"
@@ -21,9 +16,15 @@ footer: {{$:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/C
       fileDrop=no
       minHeight="30px"
     />
-
     <div class="tw-calendar-time-range-preview">
       <$view field="startDate" format="date" template={{$:/language/Tiddler/DateFormat}}/> → <$view field="endDate" format="date" template={{$:/language/Tiddler/DateFormat}}/>
     </div>
   </$let>
+  <div class="tw-calendar-tags-input">
+   
+    {{$:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/FrequentlyUsedTagsList}}
+    <div class="tw-calendar-tags-input">
+     {{$:/state/Calendar/PageLayout/create-tiddler||$:/core/ui/EditTemplate/tags}}
+  </div>
+</div>
 </div>

--- a/src/tiddlywiki-ui/popup/CreateNewTiddlerPopup.tid
+++ b/src/tiddlywiki-ui/popup/CreateNewTiddlerPopup.tid
@@ -4,7 +4,7 @@ footer: {{$:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/C
 
 <div class="tw-calendar-layout-create-new-tiddler-popup">
   Caption:{{$:/state/Calendar/PageLayout/create-tiddler-caption||$:/core/ui/EditTemplate/title}}
-  <small>Title:{{$:/plugins/linonetwo/tw-calendar/settings/prefix}}{{$:/state/Calendar/PageLayout/create-tiddler-caption!!draft.title}}{{$:/state/Calendar/PageLayout/create-tiddler!!draft.title}}</small>
+  <small>Title:{{$:/plugins/linonetwo/tw-calendar/settings/prefix}}{{$:/state/Calendar/PageLayout/create-tiddler-caption!!draft.title}}</small>
 
   <$let currentTiddler="$:/state/Calendar/PageLayout/create-tiddler">
     <$edit-text

--- a/src/tiddlywiki-ui/popup/CreateNewTiddlerPopup.tid
+++ b/src/tiddlywiki-ui/popup/CreateNewTiddlerPopup.tid
@@ -4,6 +4,8 @@ footer: {{$:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/C
 
 <div class="tw-calendar-layout-create-new-tiddler-popup">
   Caption:{{$:/state/Calendar/PageLayout/create-tiddler-caption||$:/core/ui/EditTemplate/title}}
+  <small>Title:{{$:/plugins/linonetwo/tw-calendar/settings/prefix}}{{$:/state/Calendar/PageLayout/create-tiddler-caption!!draft.title}}{{$:/state/Calendar/PageLayout/create-tiddler!!draft.title}}</small>
+
   <$let currentTiddler="$:/state/Calendar/PageLayout/create-tiddler">
     <$edit-text
       field="text"
@@ -21,10 +23,9 @@ footer: {{$:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/C
     </div>
   </$let>
   <div class="tw-calendar-tags-input">
-   
     {{$:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/FrequentlyUsedTagsList}}
     <div class="tw-calendar-tags-input">
-     {{$:/state/Calendar/PageLayout/create-tiddler||$:/core/ui/EditTemplate/tags}}
+    {{$:/state/Calendar/PageLayout/create-tiddler||$:/core/ui/EditTemplate/tags}}
+    </div>
   </div>
-</div>
 </div>

--- a/src/tiddlywiki-ui/popup/CreateNewTiddlerPopupFooter.tid
+++ b/src/tiddlywiki-ui/popup/CreateNewTiddlerPopupFooter.tid
@@ -16,7 +16,7 @@ title: $:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/Crea
 \end
 
 <!-- learn this from twMat https://groups.google.com/g/tiddlywiki/c/XXbzgRmcXF0 -->
-<$wikify name="newtitle" text="{{$:/plugins/linonetwo/tw-calendar/settings/prefix}}" >
+<$wikify name="newtitle" text="{{$:/plugins/linonetwo/tw-calendar/settings/prefix}}{{$:/state/Calendar/PageLayout/create-tiddler-caption!!draft.title}}" >
 
 <div class="tw-calendar-footer-buttons">
   <$button class="tw-calendar-footer-button" message="tm-close-tiddler">

--- a/src/tiddlywiki-ui/popup/CreateNewTiddlerPopupFooter.tid
+++ b/src/tiddlywiki-ui/popup/CreateNewTiddlerPopupFooter.tid
@@ -16,7 +16,7 @@ title: $:/plugins/linonetwo/tw-calendar/calendar-widget/tiddlywiki-ui/popup/Crea
 \end
 
 <!-- learn this from twMat https://groups.google.com/g/tiddlywiki/c/XXbzgRmcXF0 -->
-<$wikify name="newtitle" text="{{$:/plugins/linonetwo/tw-calendar/settings/prefix}}{{$:/state/Calendar/PageLayout/create-tiddler-caption!!draft.title}}{{$:/state/Calendar/PageLayout/create-tiddler!!draft.title}}" >
+<$wikify name="newtitle" text="{{$:/plugins/linonetwo/tw-calendar/settings/prefix}}" >
 
 <div class="tw-calendar-footer-buttons">
   <$button class="tw-calendar-footer-button" message="tm-close-tiddler">


### PR DESCRIPTION
删除了标题里的时区显示。标题通过前缀来实现。样式也修改了一部分，在修改的说明里。